### PR TITLE
Gh 8 template versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marklogic-community/grove-cli",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A command-line tool for generating Grove projects.",
   "main": "index.js",
   "bin": {
@@ -12,7 +12,7 @@
     "test": "npm run lint && echo \"Error: no test specified\" && exit 1",
     "test:watch": "npm run lint && echo \"Error: no test specified\" && exit 1"
   },
-  "repository": "https://project.marklogic.com/repo/users/pmcelwee/repos/grove-cli/browse",
+  "repository": "https://github.com/marklogic-community/grove-cli.git",
   "keywords": [
     "MarkLogic",
     "Grove",

--- a/src/createNew.js
+++ b/src/createNew.js
@@ -159,7 +159,7 @@ const createNew = function(options) {
           config.mlAppName
         }" using the Grove ${
           template.name
-        } UI ${template.repo}, the Grove Node middle-tier, and ml-gradle...`
+        } UI, the Grove Node middle-tier, and ml-gradle...`
       )
     );
 

--- a/src/createNew.js
+++ b/src/createNew.js
@@ -13,13 +13,12 @@ const availableTemplates = [
   {
     id: 'grove-react-template',
     name: 'React',
-    repo: 'https://project.marklogic.com/repo/scm/nacw/grove-react-template.git'
+    repo: 'https://github.com/marklogic-community/grove-react-template.git'
   },
   {
     id: 'grove-vue-template',
     name: 'Vue',
-    repo:
-      'https://project.marklogic.com/repo/scm/~gjosten/grove-vue-template.git'
+    repo: 'https://github.com/marklogic-community/grove-vue-template.git'
   }
 ];
 
@@ -160,7 +159,7 @@ const createNew = function(options) {
           config.mlAppName
         }" using the Grove ${
           template.name
-        } UI, the Grove Node middle-tier, and ml-gradle...`
+        } UI ${template.repo}, the Grove Node middle-tier, and ml-gradle...`
       )
     );
 


### PR DESCRIPTION
hot-fixes for #7 (cloning wrong templates) and #8 (repository field set to wrong location).  Includes a bump in patch version to 1.0.1.  Note: this PR is against master for a direct hot-fix.  I can publish to npm once approved and tested.